### PR TITLE
Create a manifest and adjust the path of the asset

### DIFF
--- a/components/radio/_radio.scss
+++ b/components/radio/_radio.scss
@@ -2,7 +2,7 @@
   &::before {
     display: block;
     content: 'x';
-    //background-image: asset-url('angle-up-solid.svg');
+    background-image: asset-url('assets/images/angle-up-solid.svg');
     background-size: 28px 28px;
     height: 28px;
     width: 28px;

--- a/faucet.config.js
+++ b/faucet.config.js
@@ -15,5 +15,8 @@ module.exports = {
       source: './lib/images',
       target: './assets/images'
     }
-  ]
+  ],
+  manifest: {
+    target: './assets/manifest.json'
+  }
 }


### PR DESCRIPTION
This PR fixes two things:

1. It writes the manifest to disk. Currently, this is necessary in order to receive things from the manifest. This leads to the weird `NullError: method not found: 'get' on null`. This should be fixed in faucet-pipeline-core and I will do so. Thanks for pointing it out 👍 
2. The path is `assets/images/angle-up-solid`. So it is the full path to the file. If you dislike that, you can configure it [differently as described here](https://www.faucet-pipeline.org/manifest)