### PR TITLE
Added different implementation of sorting component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- modified the implementation of the `.tabelle-arrows` component. Inserting the
+  arrows directly into the DOM is now deprecated: we recommend wrapping them
+  in a `<fieldset class="tabelle-arrows>`.
+  All changes should be backwards compatible, even though the component behaves
+  a bit differently now. However, if for some reason the `.tabelle-arrow--asc`
+  or `.tabelle-arrow--desc` labels are not wrapped in a `.tabelle-header` class,
+  this could cause bugs because the new version uses absolute positioning to
+  position the `::after` element of the `.tabelle-arrow--asc` and
+  `.tabelle-arrow--desc` in over the nearest parent with `position: relative;`
+
 ### Fixed
 - Fixed focus for `tabelle-arrows` so it is retained on a `ta-belle` submit
 - Fixed `tabelle-cljs` bug when using a custom field for filtering
+
 
 ## [0.5.0] - 2021-05-06
 ### Changed
@@ -15,14 +27,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `nofilter` attribute to `ta-belle` and `tabelle-cljs` to deactivate
   automatic generation of filter fields for the whole table
 
+
 ## [0.4.0] - 2021-04-27
 ### Added
 - `tabelle-cljs` component for client-side filtering and sorting
 - Added custom CSS properties for customizing `.tabelle-arrow`
 
+
 ## [0.3.1] - 2021-04-16
 ### Changed
 - Clean-up files for deployment
+
 
 ## [0.3.0] - 2021-04-16
 ### Changed
@@ -30,13 +45,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Moved from image URLs for the icons to inline SVG data URLs
 - Restructured project internals
 
+
 ## [0.2.2] - 2021-04-16
 ### Changed
 - Updated Dependencies
 
+
 ## [0.2.1] - 2021-01-05
 ### Changed
 - Updated Dependencies
+
 
 ## [0.2.0] - 2020-07-03
 ### Changed
@@ -48,13 +66,16 @@ themselves, then this is still supported by Tabelle.
 hasn't changed. This also fixes a bug with Firefox which fires events both on
 'keyup' and 'change' and deduplicates them.
 
+
 ## [0.1.2] - 2019-02-13
 ### Added
 - Animated GIF
 
+
 ## [0.1.1] - 2019-02-13
 ### Added
 - Make it possible to customize the length of the debounce
+
 
 ## [0.1.0] - 2019-02-08
 ### Added
@@ -73,16 +94,19 @@ hasn't changed. This also fixes a bug with Firefox which fires events both on
 ### Deprecated
 - `.hide` CSS class. Use `.visually-hidden` instead.
 
+
 ## [0.1.17] - 2019-02-08
 ### Changed
 - Update dependencies
 - reference lib/index.js to make it easier to import
 - Update README
 
+
 ## [0.1.16] - 2018-11-05
 ### Changed
 - fix npm build command
 - replace duplicate arrow functions with one submitForm function
+
 
 ## [0.1.15] - 2018-11-05
 ### Added
@@ -95,58 +119,71 @@ hasn't changed. This also fixes a bug with Firefox which fires events both on
 - Simplify linter configuration
 - Restructure and refactor JavaScript
 
+
 ## [0.1.14] - 2018-10-26
 ### Changed
 - Added way to encode the current sort direction of the Tabelle
 - Restructured and improved JavaScript
+
 
 ## [0.1.13] - 2018-10-24
 ### Changed
 - Fixed focus to move cursor to right spot
 - Move preventDefault to end of overriding form submit
 
+
 ## [0.1.12] - 2018-10-24
 ### Changed
 - Preserve focus when replacing whole `<ta-belle>`
 - Fix linter
 
+
 ## [0.0.11] - 2018-10-24
 ### Changed
 - switched to hijax-forms for form handing
+
 
 ## [0.0.10] - 2018-10-19
 ### Changed
 - Added flexibility to display a response: replace whole `<ta-belle>` element
 - Fix pushState
 
+
 ## [0.0.9] - 2018-10-12
 ### Added
 - Linting
+
 
 ## [0.0.8] - 2018-10-12
 ### Added
 - base.css
 
+
 ## [0.0.7] - 2018-10-12
 ### Changed
 - Use relative URIs for icon images
 
+
 ## [0.0.6] - 2018-10-12
 ### Added
 - Customization options for the table sort
+
 
 ## [0.0.5] - 2018-10-11
 ### Changed
 - Consider exisiting value attribute
 - Define only one sort for table
 
+
 ## [0.0.4] - 2018-10-11
 ### Changed
 - Fixed CSS Path
 
+
 ## [0.0.3] - 2018-10-11
 ### Added
 - Documentation in README
+
 
 ## [0.0.2] - 2018-10-11
 ### Added
@@ -155,6 +192,7 @@ hasn't changed. This also fixes a bug with Firefox which fires events both on
 
 ### Changed
 - CSS Structure
+
 
 ## 0.0.1 - 2018-10-10
 ### Added

--- a/README.md
+++ b/README.md
@@ -142,3 +142,7 @@ We have made the styling as minimal as possible in order to allow you to customi
 ## Resources
 
 * [Example Rails App](https://tabelle-rails-example.herokuapp.com/)
+
+## Icon Attribution
+
+Tabelle uses icons which are licensed under the [Font Awesome Free License](https://fontawesome.com/license/free).

--- a/lib/components/arrow/arrow.js
+++ b/lib/components/arrow/arrow.js
@@ -1,5 +1,10 @@
 /* eslint-env browser */
 import { createElement } from "uitil/dom/create";
+import { nid } from "uitil/uid";
+
+function idGen (prefix = "arrowId") {
+	return prefix + "-" + nid();
+}
 
 export function arrowRadio (form, id, name, direction, checked) {
 	form = form && { form };
@@ -28,4 +33,17 @@ export function arrowLabel (id, columnName, direction) {
 	return createElement("label", { for: id, class: "tabelle-arrow--" + direction },
 			createElement("span", { class: "visually-hidden" },
 					"Sort " + columnName + " " + directionName(direction)));
+}
+
+export function createArrows(form, name, columnName, currentSort) {
+	const idUp = idGen();
+	const upRadio = arrowRadio(form, idUp, name, "asc", currentSort === name + "-asc");
+	const upLabel = arrowLabel(idUp, columnName, "asc");
+
+	const idDown = idGen();
+	const downRadio = arrowRadio(form, idDown, name, "desc",
+			currentSort === name + "-desc");
+	const downLabel = arrowLabel(idDown, columnName, "desc");
+
+	return [upRadio, upLabel, downRadio, downLabel];
 }

--- a/lib/components/arrow/doc.md
+++ b/lib/components/arrow/doc.md
@@ -20,11 +20,12 @@ has sorted the table.
 You can customize the styles with the following CSS Properties.
 
 ```
---tabelle-arrow-height: ; /* Default: 1rem */
+--tabelle-arrow-height: ; /* Default: 1.5em */
 --tabelle-arrow-color: ; /* Default: #acacac */
---tabelle-arrow-color-checked: ; /* Default: #535353 */
---tabelle-arrow-color-hover: ; /* Default: #6882cb */
---tabelle-arrow-color-focus: ; /* Default: #6882cb */
+--tabelle-arrow-color-hover: ; /* Default: #757575 */
+--tabelle-arrow-sort-image: url(...); /* A valid image URL to use as a mask when unsorted */
+--tabelle-arrow-sort-up-image: url(...); /* A valid image URL to use as a mask when sorted up */
+--tabelle-arrow-sort-down-image: url(...); /* A valid image URL to use as a mask when sorted down */
 ```
 
 You can also override the focus style for the arrows using the

--- a/lib/components/arrow/doc.md
+++ b/lib/components/arrow/doc.md
@@ -27,6 +27,14 @@ You can customize the styles with the following CSS Properties.
 --tabelle-arrow-color-focus: ; /* Default: #6882cb */
 ```
 
+You can also override the focus style for the arrows using the
+following CSS property:
+
+```
+/* Default `3px solid #7fb2f8` or `3px solid -webkit-focus-ring-color` */
+--tabelle-focus-style: ;
+```
+
 Wrap the radio buttons in a `fieldset` with the `.tabelle-arrows` class.
 
 ```handlebars

--- a/lib/components/arrow/doc.md
+++ b/lib/components/arrow/doc.md
@@ -1,5 +1,5 @@
 title: Sort Arrows
-description: Style radio buttons to look like sortable arrows
+description: Style radio buttons as a sorting component
 
 Our sort options are actually radio buttons which are styled using CSS to look
 like arrows. By default, Tabelle expects that the `name` for the sort option is
@@ -27,36 +27,64 @@ You can customize the styles with the following CSS Properties.
 --tabelle-arrow-color-focus: ; /* Default: #6882cb */
 ```
 
-
-## Sort Ascending
-
-```handlebars
-<input class="tabelle-arrow" id="{{name}}_asc" type="radio" name="sort" value="{{name}}-asc"/>
-<label class="tabelle-arrow--asc" for="{{name}}_asc">
-	<span class="visually-hidden">Sort {{label}} Ascending</span>
-</label>
-```
-
-## Sort Descending
+Wrap the radio buttons in a `fieldset` with the `.tabelle-arrows` class.
 
 ```handlebars
-<input class="tabelle-arrow" id="{{name}}_desc" type="radio" name="sort" value="{{name}}-desc" />
-<label class="tabelle-arrow--desc" for="{{name}}_desc">
-	<span class="visually-hidden">Sort {{label}} Descending</span>
-</label>
+<fieldset class="tabelle-arrows">
+	<legend>Sort {{label}}</legend>
+	<input class="tabelle-arrow" id="{{name}}_asc" type="radio" name="sort" value="{{name}}-asc"/>
+	<label class="tabelle-arrow--asc" for="{{name}}_asc">
+		<span class="visually-hidden">Ascending</span>
+	</label>
+
+	<input class="tabelle-arrow" id="{{name}}_desc" type="radio" name="sort" value="{{name}}-desc" />
+	<label class="tabelle-arrow--desc" for="{{name}}_desc">
+		<span class="visually-hidden">Descending</span>
+	</label>
+</fieldset>
 ```
 
-## Arrow that is already checked
+## Arrow that is already checked (ascending)
 
 ```handlebars
-<input class="tabelle-arrow" id="{{name}}_asc" type="radio" name="sort" value="{{name}}-asc" checked />
-<label class="tabelle-arrow--asc" for="{{name}}_asc">
-	<span class="visually-hidden">Sort {{label}} Ascending</span>
-</label>
+<fieldset class="tabelle-arrows">
+	<legend>Sort {{label}}</legend>
+	<input class="tabelle-arrow" id="{{name}}_asc" type="radio" name="sort" value="{{name}}-asc" checked />
+	<label class="tabelle-arrow--asc" for="{{name}}_asc">
+		<span class="visually-hidden">Ascending</span>
+	</label>
+
+	<input class="tabelle-arrow" id="{{name}}_desc" type="radio" name="sort" value="{{name}}-desc" />
+	<label class="tabelle-arrow--desc" for="{{name}}_desc">
+		<span class="visually-hidden">Descending</span>
+	</label>
+</fieldset>
 ```
 
+## Arrow that is already checked (descending)
 
-## Multiple Arrows -- Can only select one sort option
+```handlebars
+<fieldset class="tabelle-arrows">
+	<legend>Sort {{label}}</legend>
+	<input class="tabelle-arrow" id="{{name}}_asc" type="radio" name="sort" value="{{name}}-asc" />
+	<label class="tabelle-arrow--asc" for="{{name}}_asc">
+		<span class="visually-hidden">Ascending</span>
+	</label>
+
+	<input class="tabelle-arrow" id="{{name}}_desc" type="radio" name="sort" value="{{name}}-desc" checked />
+	<label class="tabelle-arrow--desc" for="{{name}}_desc">
+		<span class="visually-hidden">Descending</span>
+	</label>
+</fieldset>
+```
+
+## Using sort arrows without a wrapping fieldset (DEPRECATED)
+
+You can also insert the arrows directly into the DOM without wrapping
+them in a `fieldset`.
+
+This is intended mainly to maintain backwards compatiblity, because previous
+versions of Tabelle did not wrap them in a `fieldset`.
 
 ```handlebars
 <input class="tabelle-arrow" id="{{name}}_asc" type="radio" name="sort" value="{{name}}-asc"/>

--- a/lib/components/arrow/index.scss
+++ b/lib/components/arrow/index.scss
@@ -1,31 +1,48 @@
+$sort-svg: 'data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="sort" class="svg-inline--fa fa-sort fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"></path></svg>';
+$sort-up-svg: 'data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="sort-up" class="svg-inline--fa fa-sort-up fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M279 224H41c-21.4 0-32.1-25.9-17-41L143 64c9.4-9.4 24.6-9.4 33.9 0l119 119c15.2 15.1 4.5 41-16.9 41z"></path></svg>';
+$sort-down-svg: 'data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="sort-down" class="svg-inline--fa fa-sort-down fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41z"></path></svg>';
+
 .tabelle-arrow {
 	& {
 		@include visually-hidden();
 	}
 
-	&--asc {
-		@include icon-before('data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="angle-up" class="svg-inline--fa fa-angle-up fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M177 159.7l136 136c9.4 9.4 9.4 24.6 0 33.9l-22.6 22.6c-9.4 9.4-24.6 9.4-33.9 0L160 255.9l-96.4 96.4c-9.4 9.4-24.6 9.4-33.9 0L7 329.7c-9.4-9.4-9.4-24.6 0-33.9l136-136c9.4-9.5 24.6-9.5 34-.1z"></path></svg>', var(--tabelle-arrow-color, $tabelle-light-gray));
-		cursor: pointer;
+	:not(:checked) + &--asc::after,
+	:checked + &--asc + :not(:checked) + &--desc::after {
+		content: "";
 		display: block;
-		height: var(--tabelle-arrow-height, 1rem);
-	}
-
-	&--desc {
-		@include icon-before('data:image/svg+xml;utf8,<svg aria-hidden="true" data-prefix="fas" data-icon="angle-down" class="svg-inline--fa fa-angle-down fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z"></path></svg>', var(--tabelle-arrow-color, $tabelle-light-gray));
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: var(--tabelle-arrow-height, 1.5em);
+		z-index: 1;
 		cursor: pointer;
-		display: block;
-		height: var(--tabelle-arrow-height, 1rem);
 	}
 
-	&:hover + &--asc::before, &:hover + &--desc::before {
-		background-color: var(--tabelle-arrow-color-hover, $tabelle-blue);
+	:not(:checked) + &--asc + :not(:checked) + &--desc {
+		@include icon-before($sort-svg, var(--tabelle-arrow-color, $tabelle-gray));
 	}
 
-	&:focus + &--asc::before, &:focus + &--desc::before {
-		background-color:  var(--tabelle-arrow-color-focus, $tabelle-blue);
+	:checked + &--asc + :not(:checked) + &--desc {
+		@include icon-before($sort-up-svg, var(--tabelle-arrow-color, $tabelle-gray));
 	}
 
-	&:checked + &--asc::before, &:checked + &--desc::before {
-		background-color: var(--tabelle-arrow-color-checked, $tabelle-gray);
+	:not(:checked) + &--asc + :checked + &--desc {
+		@include icon-before($sort-down-svg, var(--tabelle-arrow-color, $tabelle-gray));
+	}
+
+	:hover ~ &--desc {
+		--tabelle-arrow-color: var(--tabelle-arrow-color-hover, #{$tabelle-light-gray});
+	}
+}
+
+.tabelle-arrows {
+	border: 0;
+	padding: 0;
+	position: relative;
+
+	legend {
+		@include visually-hidden();
 	}
 }

--- a/lib/components/arrow/index.scss
+++ b/lib/components/arrow/index.scss
@@ -32,8 +32,26 @@ $sort-down-svg: 'data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="fals
 		@include icon-before($sort-down-svg, var(--tabelle-arrow-color, $tabelle-gray));
 	}
 
+	:focus + &--asc + :not(:checked) + &--desc,
+	:focus + &--asc + :checked + &--desc {
+		@include icon-before($sort-up-svg, var(--tabelle-arrow-color, $tabelle-gray));
+	}
+
+	:not(:checked) + &--asc + :focus + &--desc,
+	:checked + &--asc + :focus + &--desc {
+		@include icon-before($sort-down-svg, var(--tabelle-arrow-color, $tabelle-gray));
+	}
+
 	:hover ~ &--desc {
 		--tabelle-arrow-color: var(--tabelle-arrow-color-hover, #{$tabelle-light-gray});
+	}
+
+	:focus ~ &--desc {
+		outline: var(--tabelle-focus-style);
+	}
+	// Remove focus styles for mouse interaction where supported
+	:focus:not(:focus-visible) ~ &--desc {
+		outline: none;
 	}
 }
 

--- a/lib/components/arrow/index.scss
+++ b/lib/components/arrow/index.scss
@@ -1,6 +1,6 @@
-$sort-svg: 'data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="sort" class="svg-inline--fa fa-sort fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"></path></svg>';
-$sort-up-svg: 'data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="sort-up" class="svg-inline--fa fa-sort-up fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M279 224H41c-21.4 0-32.1-25.9-17-41L143 64c9.4-9.4 24.6-9.4 33.9 0l119 119c15.2 15.1 4.5 41-16.9 41z"></path></svg>';
-$sort-down-svg: 'data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="sort-down" class="svg-inline--fa fa-sort-down fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41z"></path></svg>';
+$sort-svg: url('data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="sort" class="svg-inline--fa fa-sort fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41zm255-105L177 64c-9.4-9.4-24.6-9.4-33.9 0L24 183c-15.1 15.1-4.4 41 17 41h238c21.4 0 32.1-25.9 17-41z"></path></svg>');
+$sort-up-svg: url('data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="sort-up" class="svg-inline--fa fa-sort-up fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M279 224H41c-21.4 0-32.1-25.9-17-41L143 64c9.4-9.4 24.6-9.4 33.9 0l119 119c15.2 15.1 4.5 41-16.9 41z"></path></svg>');
+$sort-down-svg: url('data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="sort-down" class="svg-inline--fa fa-sort-down fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="currentColor" d="M41 288h238c21.4 0 32.1 25.9 17 41L177 448c-9.4 9.4-24.6 9.4-33.9 0L24 329c-15.1-15.1-4.4-41 17-41z"></path></svg>');
 
 .tabelle-arrow {
 	& {
@@ -20,26 +20,33 @@ $sort-down-svg: 'data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="fals
 		cursor: pointer;
 	}
 
-	:not(:checked) + &--asc + :not(:checked) + &--desc {
-		@include icon-before($sort-svg, var(--tabelle-arrow-color, $tabelle-gray));
+	&--desc::before {
+		width: 1em;
+		height: 1em;
+		background-color: var(--tabelle-arrow-color, $tabelle-gray);
+		display: block;
+		content: ' ';
+		mask-image: var(--tabelle-arrow-sort-image, $sort-svg);
+		mask-repeat: no-repeat;
+		mask-position: center;
 	}
 
-	:checked + &--asc + :not(:checked) + &--desc {
-		@include icon-before($sort-up-svg, var(--tabelle-arrow-color, $tabelle-gray));
+	:checked + &--asc + :not(:checked) + &--desc::before {
+		mask-image: var(--tabelle-arrow-sort-up-image, $sort-up-svg);
 	}
 
-	:not(:checked) + &--asc + :checked + &--desc {
-		@include icon-before($sort-down-svg, var(--tabelle-arrow-color, $tabelle-gray));
+	:not(:checked) + &--asc + :checked + &--desc::before {
+		mask-image: var(--tabelle-arrow-sort-down-image, $sort-down-svg);
 	}
 
-	:focus + &--asc + :not(:checked) + &--desc,
-	:focus + &--asc + :checked + &--desc {
-		@include icon-before($sort-up-svg, var(--tabelle-arrow-color, $tabelle-gray));
+	:focus + &--asc + :not(:checked) + &--desc::before,
+	:focus + &--asc + :checked + &--desc::before {
+		mask-image: var(--tabelle-sort-up-svg, $sort-up-svg);
 	}
 
-	:not(:checked) + &--asc + :focus + &--desc,
-	:checked + &--asc + :focus + &--desc {
-		@include icon-before($sort-down-svg, var(--tabelle-arrow-color, $tabelle-gray));
+	:not(:checked) + &--asc + :focus + &--desc::before,
+	:checked + &--asc + :focus + &--desc::before {
+		mask-image: var(--tabelle-sort-down-svg, $sort-down-svg);
 	}
 
 	:hover ~ &--desc {

--- a/lib/components/header/doc.md
+++ b/lib/components/header/doc.md
@@ -17,15 +17,18 @@ You can customize the layout with the following CSS Properties.
 ```handlebars
 <div class="tabelle-header" role="group" aria-labelledby="{{name}}_group">
 	<span class="header" id="{{name}}_group">{{label}}</span>
-	<input class="tabelle-arrow" id="{{name}}_asc" type="radio" name="sort" value="{{name}}-asc"/>
-	<label class="tabelle-arrow--asc" for="{{name}}_asc">
-		<span class="visually-hidden">Sort {{label}} Ascending</span>
-	</label>
+	<fieldset class="tabelle-arrows">
+		<legend>Sort {{label}}</legend>
+		<input class="tabelle-arrow" id="{{name}}_asc" type="radio" name="sort" value="{{name}}-asc"/>
+		<label class="tabelle-arrow--asc" for="{{name}}_asc">
+			<span class="visually-hidden">Ascending</span>
+		</label>
 
-	<input class="tabelle-arrow" id="{{name}}_desc" type="radio" name="sort" value="{{name}}-desc" />
-	<label class="tabelle-arrow--desc" for="{{name}}_desc">
-		<span class="visually-hidden">Sort {{label}} Descending</span>
-	</label>
+		<input class="tabelle-arrow" id="{{name}}_desc" type="radio" name="sort" value="{{name}}-desc" />
+		<label class="tabelle-arrow--desc" for="{{name}}_desc">
+			<span class="visually-hidden">Descending</span>
+		</label>
+	</fieldset>
 
 	<input
 		class="tabelle-input"
@@ -40,15 +43,19 @@ You can customize the layout with the following CSS Properties.
 ```handlebars
 <div class="tabelle-header" role="group" aria-labelledby="{{name}}_group">
 	<span class="header" id="{{name}}_group">{{label}}</span>
-	<input class="tabelle-arrow" id="{{name}}_asc" type="radio" name="sort" value="{{name}}-asc"/>
-	<label class="tabelle-arrow--asc" for="{{name}}_asc">
-		<span class="visually-hidden">Sort {{label}} Ascending</span>
-	</label>
 
-	<input class="tabelle-arrow" id="{{name}}_desc" type="radio" name="sort" value="{{name}}-desc" />
-	<label class="tabelle-arrow--desc" for="{{name}}_desc">
-		<span class="visually-hidden">Sort {{label}} Descending</span>
-	</label>
+	<fieldset class="tabelle-arrows">
+		<legend>Sort {{label}}</legend>
+		<input class="tabelle-arrow" id="{{name}}_asc" type="radio" name="sort" value="{{name}}-asc"/>
+		<label class="tabelle-arrow--asc" for="{{name}}_asc">
+			<span class="visually-hidden">Ascending</span>
+		</label>
+
+		<input class="tabelle-arrow" id="{{name}}_desc" type="radio" name="sort" value="{{name}}-desc" />
+		<label class="tabelle-arrow--desc" for="{{name}}_desc">
+			<span class="visually-hidden">Descending</span>
+		</label>
+	</fieldset>
 
 	<select class="tabelle-input"
 		name="{{name}}"
@@ -79,14 +86,17 @@ You can customize the layout with the following CSS Properties.
 ```handlebars
 <div class="tabelle-header" role="group" aria-labelledby="{{name}}_group">
 	<span class="header" id="{{name}}_group">{{label}}</span>
-	<input class="tabelle-arrow" id="{{name}}_asc" type="radio" name="sort" value="{{name}}-asc"/>
-	<label class="tabelle-arrow--asc" for="{{name}}_asc">
-		<span class="visually-hidden">Sort {{label}} Ascending</span>
-	</label>
+	<fieldset class="tabelle-arrows">
+		<legend>Sort {{label}}</legend>
+		<input class="tabelle-arrow" id="{{name}}_asc" type="radio" name="sort" value="{{name}}-asc"/>
+		<label class="tabelle-arrow--asc" for="{{name}}_asc">
+			<span class="visually-hidden">Ascending</span>
+		</label>
 
-	<input class="tabelle-arrow" id="{{name}}_desc" type="radio" name="sort" value="{{name}}-desc" />
-	<label class="tabelle-arrow--desc" for="{{name}}_desc">
-		<span class="visually-hidden">Sort {{label}} Descending</span>
-	</label>
+		<input class="tabelle-arrow" id="{{name}}_desc" type="radio" name="sort" value="{{name}}-desc" />
+		<label class="tabelle-arrow--desc" for="{{name}}_desc">
+			<span class="visually-hidden">Descending</span>
+		</label>
+	</fieldset>
 </div>
 ```

--- a/lib/components/header/header.js
+++ b/lib/components/header/header.js
@@ -2,13 +2,9 @@
 import { extractContent } from "../../util";
 import { replaceNode } from "uitil/dom";
 import { createElement } from "uitil/dom/create";
-import { arrowRadio, arrowLabel } from "../arrow/arrow";
+import { createArrows } from "../arrow/arrow";
 import { createFilter } from "../input/input";
 import { nid } from "uitil/uid";
-
-function idGen (prefix = "arrowId") {
-	return prefix + "-" + nid();
-}
 
 function setFormFor (input, form) {
 	if (input && form) {
@@ -19,27 +15,18 @@ function setFormFor (input, form) {
 
 function createHeader ({ form, name, input, value, nosort, nofilter, currentSort },
 		tdContent) {
-	const headerId = idGen("header");
+	const headerId = "header" + "-" + nid();
 	const columnName = tdContent.textContent;
 	const header = createElement("span", { class: "header", id: headerId }, tdContent);
-	const idUp = idGen();
-	const upRadio = nosort ? "" :
-		arrowRadio(form, idUp, name, "asc", currentSort === name + "-asc");
-	const upLabel = nosort ? "" :
-		arrowLabel(idUp, columnName, "asc");
 
-	const idDown = idGen();
-	const downRadio = nosort ? "" :
-		arrowRadio(form, idDown, name, "desc", currentSort === name + "-desc");
-	const downLabel = nosort ? "" :
-		arrowLabel(idDown, columnName, "desc");
+	const sort = nosort ? [] : createArrows(form, name, columnName, currentSort);
 
 	const filter = setFormFor(input, form) ||
 		createFilter(form, name, value, columnName, nofilter);
 
 	return createElement("div",
 			{ class: "tabelle-header", role: "group", "aria-labelledby": headerId },
-			header, upRadio, upLabel, downRadio, downLabel, filter);
+			header, ...sort, filter);
 }
 
 export function transformHeaders (headers, formId, currentSort, nofilter) {
@@ -48,11 +35,11 @@ export function transformHeaders (headers, formId, currentSort, nofilter) {
 		const value = th.getAttribute("value");
 		const headerContent = extractContent(th);
 		const properties = {
-			name: name,
-			value: value,
+			name,
+			value,
 			input: th.querySelector(".tabelle-input"),
 			form: formId,
-			currentSort: currentSort,
+			currentSort,
 			nosort: th.hasAttribute("nosort"),
 			nofilter: nofilter || th.hasAttribute("nofilter")
 		};

--- a/lib/components/header/header.js
+++ b/lib/components/header/header.js
@@ -30,7 +30,7 @@ function createHeader ({ form, name, input, value, nosort, nofilter, currentSort
 }
 
 export function transformHeaders (headers, formId, currentSort, nofilter) {
-	headers.filter(th => th.getAttribute("name")).forEach(th => {
+	let newHeaders = headers.filter(th => th.getAttribute("name")).map(th => {
 		const name = th.getAttribute("name");
 		const value = th.getAttribute("value");
 		const headerContent = extractContent(th);
@@ -45,8 +45,88 @@ export function transformHeaders (headers, formId, currentSort, nofilter) {
 		};
 
 		const newContent = createHeader(properties, headerContent);
-		replaceNode(th, createElement("th",
+		const newHeader = createElement("th",
 				{ "data-name": name, scope: "col" },
-				newContent));
+				newContent);
+		replaceNode(th, newHeader);
+
+		return newHeader;
+	});
+
+	addRadioFocus(newHeaders);
+}
+
+/*
+We want to use the default behavior of a radio button to our advantage,
+but for keyboard users the radio buttons _look_ like buttons, so you expect
+the focus management to _behave_ like buttons as well. With the default
+focus behavior, when a radio button has been selected, any radio button without
+the same exact `name` will no longer be able to be focused via `tab`.
+
+With this function, we implement custom focus management for the input fields
+within the Tabelle header. We iterate through all of the form input fields in
+the header and ensure that the focus follows the order of elements in the HTML.
+
+The `.tabelle-arrow` is also problematic when it is the first focussable child
+in the headers (tabbing _into_ the component will not reliably select the arrow
+as the first child). To work around this, we make the `table` focussable via
+tab and then ensure that the focus will move correctly from the table to
+the first arrow.
+
+The `.tabelle-arrow` is also problematic if it is the last focussable child in
+the headers (doesn't occur that often because often the `.tabelle-input` will
+be the last child). For this we add a workaround and make the last `label`
+focussable via keyboard to escape the focus trap from the arrow. This is maybe
+not completely ideal, but it allows users to continue tabbing through the
+interface with only one tab.
+*/
+function addRadioFocus(headers) {
+	let elements = headers.map(header => {
+		let arrowUp = header.querySelector(".tabelle-arrow[value$=-asc]");
+		let arrowDown = header.querySelector(".tabelle-arrow[value$=-desc]");
+		let input = header.querySelector(".tabelle-input");
+
+		return [arrowUp, arrowDown, input].filter(e => e);
+	}).filter(elements => elements.length).flat();
+
+	if (!elements.length) {
+		return;
+	}
+
+	let table = elements[0].closest("table");
+	table.setAttribute("tabindex", "0");
+
+	elements = [table].concat(elements);
+
+	if (elements[elements.length - 1].classList.contains("tabelle-arrow")) {
+		// Manually setting the focus on the `.tabelle-arrow` is problematic when
+		// the `.tabelle-arrow` is the last focussable element in the header
+		// because then the focus gets trapped within the arrow when you are tab
+		// through the interface. This workaround makes the label behind the arrow
+
+		let header = elements[elements.length - 1].parentNode;
+		let label = header.querySelector(".tabelle-arrow--desc");
+		elements = elements.concat(label);
+		label.setAttribute("tabindex", 0);
+	}
+
+	elements.forEach((element, i) => {
+		let prev = i > 0 && elements[i - 1];
+		let next = i < elements.length && elements[i + 1];
+
+		element.addEventListener("keydown", event => {
+			if (element !== event.target) {
+				return;
+			}
+
+			if (event.key === "Tab" && !event.shiftKey && next) {
+				event.preventDefault();
+				next.focus();
+			}
+			if (event.key === "Tab" && event.shiftKey && prev) {
+				event.preventDefault();
+				prev.focus();
+			}
+		});
 	});
 }

--- a/lib/components/header/index.scss
+++ b/lib/components/header/index.scss
@@ -2,30 +2,34 @@
 	display: grid;
 	grid-template-columns: 1fr auto;
 	grid-template-rows:
-		var(--tabelle-arrow-height, 1rem)
-		var(--tabelle-arrow-height, 1rem)
+		var(--tabelle-header-height, 1.5em)
 		var(--tabelle-filter-height, auto);
 	column-gap: var(--tabelle-column-gap, 0.125rem);
 	grid-template-areas:
-		"header arrow-asc"
-		"header arrow-desc"
+		"header arrows"
 		"search search";
 	align-items: start;
+	position: relative;
 
 	.header {
 		grid-area: header;
 		align-self: center;
 	}
 
-	.tabelle-arrow--asc {
-		grid-area: arrow-asc;
-	}
-
-	.tabelle-arrow--desc {
-		grid-area: arrow-desc;
+	.tabelle-arrows {
+		grid-area: arrows;
+		align-self: center;
+		position: static;
 	}
 
 	input, select, .tabelle-input {
 		grid-area: search;
+	}
+
+	/* DEPRECATED: wrap arrows in .tabelle-arrows fieldset */
+	.tabelle-arrow--asc,
+	.tabelle-arrow--desc {
+		grid-area: arrows;
+		align-self: center;
 	}
 }

--- a/lib/components/tabelle-cljs/doc.md
+++ b/lib/components/tabelle-cljs/doc.md
@@ -37,6 +37,12 @@ up client-side filtering and sorting with JavaScript!
 </tabelle-cljs>
 ```
 
+Additionally, the component also implements keyboard usability within the
+table by ensuring that the focus will move through all of the controls in
+the Tabelle sequentially (the default focus behavior of radio buttons is
+maybe not exactly what a user would expect because browsers expect users
+to iterate through radio buttons using arrows instead of the Tab key).
+
 ## Customizing filter classes
 
 **Note:** Internally, Tabelle uses [List.js](https://listjs.com/) to sort and

--- a/lib/components/tabelle/doc.md
+++ b/lib/components/tabelle/doc.md
@@ -110,8 +110,15 @@ you are replacing more than one table on a page). You also need to specify
 a `search-src` attribute which will tell the `ta-belle` the endpoint for the
 search resource which will return a new filtered or sorted HTML table.
 
-The `ta-belle` also implements an auto submit so that the filtering and sorting
-will occur whenever the user changes the filter/sort fields.
+The `ta-belle` also implements extra features which are nice for users. This
+includes an auto submit so that the filtering and sorting will occur whenever
+the user changes the filter/sort fields.
+
+Additionally, the custom element also improves the keyboard usability of the
+table by ensuring that the focus will move through all of the controls in
+the Tabelle sequentially (the default focus behavior of radio buttons is
+maybe not exactly what a user would expect because browsers expect users
+to iterate through radio buttons using arrows instead of the Tab key).
 
 ```handlebars
 <ta-belle id="tabelle" search-src="/tabelle/1.html">

--- a/lib/style/base.scss
+++ b/lib/style/base.scss
@@ -1,6 +1,14 @@
 @import 'mixins';
 @import 'colors';
 
+:root {
+	--tabelle-focus-style: 3px solid #7fb2f8;
+
+	@supports(outline: 3px auto -webkit-focus-ring-color) {
+		--tabelle-focus-style: 3px auto -webkit-focus-ring-color;
+	}
+}
+
 @import '../components/arrow/';
 @import '../components/header/';
 @import '../components/tabelle/tabelle';

--- a/lib/style/colors.scss
+++ b/lib/style/colors.scss
@@ -1,4 +1,4 @@
-$tabelle-light-gray: #acacac;
+$tabelle-light-gray: #757575;
 $tabelle-gray: #535353;
 $tabelle-blue: #6882cb;
 $tabelle-background-color: #fff;

--- a/lib/style/colors.scss
+++ b/lib/style/colors.scss
@@ -1,4 +1,3 @@
 $tabelle-light-gray: #757575;
 $tabelle-gray: #535353;
-$tabelle-blue: #6882cb;
 $tabelle-background-color: #fff;

--- a/lib/style/mixins.scss
+++ b/lib/style/mixins.scss
@@ -1,7 +1,7 @@
 @mixin icon-before($svg-path, $color) {
 	&::before {
-		width: 1rem;
-		height: 1rem;
+		width: 1em;
+		height: 1em;
 		background-color: $color;
 		display: block;
 		content: ' ';

--- a/lib/style/mixins.scss
+++ b/lib/style/mixins.scss
@@ -1,16 +1,3 @@
-@mixin icon-before($svg-path, $color) {
-	&::before {
-		width: 1em;
-		height: 1em;
-		background-color: $color;
-		display: block;
-		content: ' ';
-		mask-image: url($svg-path);
-		mask-repeat: no-repeat;
-		mask-position: center;
-	}
-}
-
 @mixin visually-hidden() { /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
 	position: absolute !important;
 	height: 1px; width: 1px;


### PR DESCRIPTION
modified the implementation of the `.tabelle-arrows` component.
Inserting the arrows directly into the DOM is now deprecated: we
recommend wrapping them in a `<fieldset class="tabelle-arrows>`. All
changes should be backwards compatible, even though the component
behaves a bit differently now. However, if for some reason the
`.tabelle-arrow--asc` or `.tabelle-arrow--desc` labels are not wrapped
in a `.tabelle-header` class, this could cause bugs because the new
version uses absolute positioning to position the `::after` element of
the `.tabelle-arrow--asc` and `.tabelle-arrow--desc` in over the nearest
parent with `position: relative;`