### PR TITLE
Added tabelle-search component for searching over multiple columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 Unreleased
 ----------
 
-- TBD
+- [minor] added `tabelle-search` component for searching over multiple columns
 
 
 1.2.0 - 2022-01-19

--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ the server and for other tables, the progressively enhanced version is
 sufficient. The CSS and HTML Markup for both is compatible, so any styling or
 customization that you do will work for both.
 
+## Tabelle Search
+
+It is also possible to add a `<tabelle-search>` component which connects to a
+Tabelle and provides the Tabelle with a search over all columns within the
+table. The `<tabelle-search>` component communicates with the Tabelle by
+sending an Event to the Tabelle implementation while the user is typing in
+an input field contained in the component. This works with either the
+`<ta-belle>` or `<tabelle-cljs>` components.
+
 ## Options
 
 In `<ta-belle>` or `<tabelle-cljs>` you can add the following properties to activate the following behavior
@@ -138,6 +147,15 @@ In the `<th>` headers, you can add the following properties to activate the foll
 |value     |specifies value which will be set for the generated input field|
 |nosort    |if no sorting functions should be generated for the column|
 |nofilter  |if not filtering functions are generated for the column|
+
+If the `<tabelle-search>` is positioned within either a `<ta-belle>`
+or `<tabelle-cljs>` no further configuration is needed. If the
+`<tabelle-search>` is positioned outside of the Tabelle, it can be configured
+as follows:
+
+|Property|Behavior|
+|--------|--------|
+|tabelleId|Indicates the HTML ID of the Tabelle with which the `<tabelle-search>` should communicate|
 
 ## Styling
 

--- a/aiur.config.js
+++ b/aiur.config.js
@@ -21,13 +21,28 @@ module.exports = {
 			file: "./lib/components/header/doc.md",
 			data: "./lib/components/header/header.data.js"
 		},
+		tabelle_search: {
+			file: "./lib/components/tabelle-search/doc.md"
+		},
 		tabelle: {
 			file: "./lib/components/tabelle/doc.md",
-			data: "./lib/components/tabelle/tabelle.data.js"
+			data: "./lib/components/tabelle/tabelle.data.js",
+			children: {
+				tabelle_search: {
+					file: "./lib/components/tabelle/search-doc.md",
+					data: "./lib/components/tabelle/tabelle.data.js"
+				}
+			}
 		},
 		tabelle_cljs: {
 			file: "./lib/components/tabelle-cljs/doc.md",
-			data: "./lib/components/tabelle-cljs/tabelle-cljs.data.js"
+			data: "./lib/components/tabelle-cljs/tabelle-cljs.data.js",
+			children: {
+				tabelle_search: {
+					file: "./lib/components/tabelle-cljs/search-doc.md",
+					data: "./lib/components/tabelle-cljs/tabelle-cljs.data.js"
+				}
+			}
 		}
 	},
 

--- a/lib/components/tabelle-cljs/doc.md
+++ b/lib/components/tabelle-cljs/doc.md
@@ -353,7 +353,7 @@ or `desc`).
 </tabelle-cljs>
 ```
 
-### Deactivating filter-fields for a Tabelle
+## Deactivating filter-fields for a Tabelle
 
 When you set the `nofilter` attribute on a `tabelle-cljs`, no
 filter fields will be generated within the table headers. This

--- a/lib/components/tabelle-cljs/index.js
+++ b/lib/components/tabelle-cljs/index.js
@@ -86,6 +86,10 @@ export class TabelleCljs extends HTMLElement {
 		this.addEventListener("keyup",
 				debounce(300, listenForChange("tabelle-input",
 						this.filter.bind(this), this.valueCache)));
+		this.addEventListener("tabelle-search", ev => {
+			this.globalFilter = ev.detail.value;
+			this.filter();
+		});
 	}
 
 	initSortAndFilter() {
@@ -128,12 +132,20 @@ export class TabelleCljs extends HTMLElement {
 	}
 
 	filter() {
-		this.list.search("_", this.searchFunction.bind(this));
+		this.list.search(this.globalFilter || "_", this.searchFunction.bind(this));
 	}
 
-	searchFunction(_searchString, _columns) {
+	searchFunction(searchString, _columns) {
 		this.list.items.forEach(item => {
-			item.found = true;
+			item.found = searchString === "_";
+
+			for (let key in item.values()) {
+				let value = item.values()[`${key}`].filter;
+
+				item.found = item.found ||
+					value.toLowerCase().trim().includes(searchString);
+			}
+
 			for (let key in this.valueCache) {
 				if (key === "sort") continue;
 

--- a/lib/components/tabelle-cljs/search-doc.md
+++ b/lib/components/tabelle-cljs/search-doc.md
@@ -1,0 +1,73 @@
+title: Tabelle Search within tabelle-cljs
+description: Adding filter field to table to filter all columns in the table
+
+It is possible to add an additional field to filter all of the columns
+using the `tabelle-search` component either as a direct child of the
+`tabelle-cljs` or by referencing the HTML ID of the `tabelle-cljs` in
+the `tabelleId` attribute of the `tabelle-search` component. See
+[the documentation on `tabelle-search`](/tabelle_search/) for more
+information.
+
+**Note:** At this time, only a single `tabelle-search` field is supported
+for the `tabelle-cljs` component. If more than one field are available on
+the page, their filter values will continually override each other.
+
+## Example with `tabelle-search` as a direct child of tabelle-cljs
+
+```handlebars
+<tabelle-cljs>
+	<tabelle-search hidden>
+		<label for="table-filter">Filter Table:</label>
+		<input id="table-filter" type="search">
+		<button>Search</button>
+	</tabelle-search>
+	<table>
+		<thead>
+			<tr>
+				<th>Column 1</th>
+				<th>Column 2</th>
+				<th>Column 3</th>
+			</tr>
+		</thead>
+		<tbody>
+			{{#each rows}}
+				<tr>
+				{{#each this}}
+					<td>{{this}}</td>
+				{{/each}}
+				</tr>
+			{{/each}}
+		</tbody>
+	</table>
+</tabelle-cljs>
+```
+
+## Example `tabelle-search` referencing `tabelle-cljs` via id
+
+```handlebars
+<tabelle-search hidden tabelleId="tabelle">
+	<label for="table-filter">Filter Table:</label>
+	<input id="table-filter" type="search">
+	<button>Search</button>
+</tabelle-search>
+<tabelle-cljs id="tabelle">
+	<table>
+		<thead>
+			<tr>
+				<th>Column 1</th>
+				<th>Column 2</th>
+				<th>Column 3</th>
+			</tr>
+		</thead>
+		<tbody>
+			{{#each rows}}
+				<tr>
+				{{#each this}}
+					<td>{{this}}</td>
+				{{/each}}
+				</tr>
+			{{/each}}
+		</tbody>
+	</table>
+</tabelle-cljs>
+```

--- a/lib/components/tabelle-search/_tabelle-search.scss
+++ b/lib/components/tabelle-search/_tabelle-search.scss
@@ -1,0 +1,3 @@
+tabelle-search {
+	display: block;
+}

--- a/lib/components/tabelle-search/doc.md
+++ b/lib/components/tabelle-search/doc.md
@@ -1,0 +1,174 @@
+title: Tabelle Search
+description: Providing a global search field for a Tabelle
+
+A `tabelle-search` component can be used in combination with a Tabelle
+in order to provide a search function globally within the Tabelle.
+A `tabelle-search` component can be associated with both the progressively
+enhanced [`ta-belle`](/tabelle/) or the client-side
+[`tabelle-cljs`](/tabelle_cljs/) elements by either placing the element
+directly within the Tabelle element or by adding a `tabelleId` attribute
+to the `tabelle-search` component referencing the HTML ID of the Tabelle
+element so that the `tabelle-search` component can interact with the
+Tabelle in question. The `tabelleId` attribute will make the most sense
+when the search field needs to be placed outside of the Tabelle element
+for layout reasons. See more documentation and examples of how the component
+works within the [`ta-belle` element](/tabelle/tabelle_search/) and within
+the [`tabelle-cljs` element](/tabelle_cljs/tabelle_search/).
+
+The `tabelle-search` element expects an `input` element to be placed inside
+of the component. The element does not generate its own input fields because
+we assume that users of this library want to use their own input fields that
+are styled according to their corporate design.
+
+```handlebars
+<tabelle-search>
+	<label for="tabelle-search">Filter Table</label>
+	<input id="tabelle-search" type="search">
+</tabelle-search>
+```
+
+
+## Custom Events sent by `tabelle-search` component
+
+The `tabelle-search` component communicates with the Tabelle element by
+sending a custom `"tabelle-search"` Event. The Event is specified as follows:
+
+### Event Name
+
+`tabelle-search`
+
+### Event Detail
+
+the `detail` of the `"tabelle-search"` will be an object containing the
+following properties:
+
+<table>
+	<thead>
+		<tr><th>Property</th><th>Description</th></tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>name</td>
+			<td>
+				The <code>name</code> of the input field wrapped within the
+				<code>tabelle-search</code> component
+			</td>
+		</tr>
+		<tr>
+			<td>value</td>
+			<td>
+				The current value of the input field wrapped within the
+				<code>tabelle-search</code> component
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+### Event Dispatching
+
+If the `tabelle-search` has a `tabelleId`, the Event will be dispatched
+directly to the element referenced by that ID. Otherwise, the Event is
+dispatched on the `tabelle-search` element and bubbles up to any parent nodes.
+The assumption is then that the `tabelle-search` is contained within a Tabelle,
+and the Tabelle will intercept this event and perform the search.
+
+
+## Progressive Enhancement
+
+The `tabelle-search` component works well with progressive enhancement because
+the input element can be nested within a form which performs the filtering of
+the table. However, if the `tabelle-search` is intended to be used
+_exclusively_ with client-side JavaScript, the element should be rendered with
+a `hidden` attribute. The `tabelle-search` element is smart enough to know how
+to unhide itself once JavaScript is available.
+
+```handlebars
+<tabelle-search hidden>
+	<label for="tabelle-search">Filter Table</label>
+	<input id="tabelle-search" type="search">
+</tabelle-search>
+```
+
+
+## Accessibility
+
+`tabelle-search` is also opinionated about the accessibility of the input
+field that is placed within its protection. If an input field is placed
+within a `tabelle-search` without a label that can be recognized by
+assistive technologies, the `tabelle-search` component will add an ugly
+red border to that input field in the hopes that the hideousness of the
+aesthetics of the input field will cause the developer to come to their
+senses and add a label.
+
+### Invalid input field without a label
+
+```handlebars
+<tabelle-search>
+	<input name="oh-no">
+</tabelle-search>
+```
+
+### Valid input field with a label referencing it via its `for` attribute
+
+```handlebars
+<tabelle-search>
+	<label for="tabelle-search">Filter Table</label>
+	<input id="tabelle-search" type="search">
+</tabelle-search>
+```
+
+### Valid input field with label that hides the label visually
+
+```handlebars
+<tabelle-search>
+	<label class="visually-hidden" for="tabelle-search">Filter Table</label>
+	<input id="tabelle-search" type="search">
+</tabelle-search>
+```
+
+### Valid input field which is nested within a label
+
+```handlebars
+<tabelle-search>
+	<label>
+		Filter Table
+		<input type="search">
+	</label>
+</tabelle-search>
+```
+
+### Valid input field which adds a label with the `aria-label` attribute
+
+```handlebars
+<tabelle-search>
+	<input type="search" aria-label="Filter Table">
+</tabelle-search>
+```
+
+### Valid input field which adds a label using the `aria-labelledby` attribute
+
+**Note:** The fact that the component supports this attribute does not mean
+that it is the best way to add a label to an input field. If in doubt, use the
+actual `label` element.
+
+```handlebars
+<span id="filter-table">Filter Table</span>
+<tabelle-search>
+	<input type="search" aria-labelledby="filter-table">
+</tabelle-search>
+```
+
+
+## Debouncing
+
+The `tabelle-search` element will not send an event upon every keystroke, but
+will instead debounce the input for a number of milliseconds (default 300)
+before sending the event. This number can be customized with the `debounce`
+attribute.
+
+```handlebars
+<tabelle-search hidden debounce="400">
+	<label for="tabelle-search">Filter Table</label>
+	<input id="tabelle-search" type="search">
+</tabelle-search>
+```

--- a/lib/components/tabelle-search/index.js
+++ b/lib/components/tabelle-search/index.js
@@ -1,0 +1,80 @@
+/* eslint-env browser */
+
+import debounce from "uitil/debounce";
+import { find } from "uitil/dom";
+
+function findLabel(input) {
+	if (input.id && document.querySelector(`label[for="${input.id}"]`)) {
+		return true;
+	}
+	if (input.closest("label")) {
+		return true;
+	}
+	if (input.getAttribute("aria-label")) {
+		return true;
+	}
+	if (input.hasAttribute("aria-labelledby") &&
+		document.querySelector(`[id=${input.getAttribute("aria-labelledby")}]`)) {
+		return true;
+	}
+	return false;
+}
+
+export class TabelleSearch extends HTMLElement {
+	connectedCallback() {
+		if (!this.input) {
+			return;
+		}
+
+		this.hidden = false;
+
+		if (!findLabel(this.input)) {
+			console.error("Expected a label for this input field: ", this.input);
+			this.input.style.border = "3px solid red";
+		}
+
+		this.input.addEventListener("keyup",
+				debounce(this.debounce, this.sendSearchEvent.bind(this)));
+		this.input.addEventListener("search", this.sendSearchEvent.bind(this));
+		this.sendSearchEvent();
+
+		find(this, "[type=submit], button:not([type=button]):not([type=reset])").forEach(
+				button => button.addEventListener("click", ev => {
+					ev.preventDefault();
+					this.sendSearchEvent();
+				}));
+	}
+
+	sendSearchEvent() {
+		// Check cached values because this event is called on "keyup", "search",
+		// and when a submit button is clicked. We want to avoid unnecessary events
+		// if possible because certain Tabelle components can trigger a form submit
+		// when this event is sent.
+		if (this.input.value === this.cachedValue) {
+			return;
+		}
+
+		let eventTarget = this.tabelle || this;
+		this.cachedValue = this.input.value;
+		eventTarget.dispatchEvent(new CustomEvent("tabelle-search", {
+			detail: {
+				name: this.input.value,
+				value: this.cachedValue
+			},
+			bubbles: !this.tabelle
+		}));
+	}
+
+	get tabelle() {
+		let tabelleId = this.getAttribute("tabelleId");
+		return tabelleId && document.getElementById(tabelleId);
+	}
+
+	get input() {
+		return this.querySelector("input");
+	}
+
+	get debounce () {
+		return parseInt(this.getAttribute("debounce")) || 300;
+	}
+}

--- a/lib/components/tabelle/index.js
+++ b/lib/components/tabelle/index.js
@@ -81,6 +81,12 @@ export default class Tabelle extends HTMLElement {
 		this.addEventListener("keyup",
 				debounce(this.debounce,
 						listenForChange("tabelle-input", submitForm, valueCache)));
+		this.addEventListener("tabelle-search", ev => {
+			if (valueCache[ev.detail.name] !== ev.detail.value) {
+				valueCache[ev.detail.name] = ev.detail.value;
+				this.submitForm();
+			}
+		});
 
 		form.addEventListener("submit", ev => {
 			this.submitForm();

--- a/lib/components/tabelle/search-doc.md
+++ b/lib/components/tabelle/search-doc.md
@@ -1,0 +1,78 @@
+title: Tabelle Search within ta-belle
+description: Adding filter field to table to filter all columns in the table
+
+It is possible to add an additional field to filter all of the columns
+using the `tabelle-search` component either as a direct child of the
+`ta-belle` or by referencing the HTML ID of the `ta-belle` in
+the `tabelleId` attribute of the `tabelle-search` component. See
+[the documentation on `tabelle-search`](/tabelle_search/) for more
+information.
+
+As with other features for the `ta-belle` element, the actual search
+behavior must be implemented on the server.
+
+## Example with `tabelle-search` as a direct child of ta-belle
+
+```handlebars
+<ta-belle id="tabelle">
+	<form id="tabelle-form" action="/tabelle/tabelle_search/0.html">
+		<tabelle-search hidden>
+			<label for="table-filter">Filter Table:</label>
+			<input id="table-filter" type="search" name="table-filter">
+			<button>Search</button>
+		</tabelle-search>
+		<table>
+			<thead>
+				<tr>
+					<th name="foo">Column 1</th>
+					<th name="bar">Column 2</th>
+					<th name="baz">Column 3</th>
+				</tr>
+			</thead>
+			<tbody>
+				{{#each rows}}
+					<tr>
+					{{#each this}}
+						<td>{{this}}</td>
+					{{/each}}
+					</tr>
+				{{/each}}
+			</tbody>
+		</table>
+		<button class="hide" type="submit">Perform Sort / Filter</button>
+	</form>
+</ta-belle>
+```
+
+## Example `tabelle-search` referencing `ta-belle` via id
+
+```handlebars
+<tabelle-search hidden tabelleId="tabelle">
+	<label for="table-filter">Filter Table:</label>
+	<input id="table-filter" type="search" name="tabelle-filter" form="tabelle-form">
+	<button>Search</button>
+</tabelle-search>
+<ta-belle id="tabelle">
+	<form id="tabelle-form" action="/tabelle/tabelle_search/1.html">
+		<table>
+			<thead>
+				<tr>
+					<th name="foo">Column 1</th>
+					<th name="bar">Column 2</th>
+					<th name="baz">Column 3</th>
+				</tr>
+			</thead>
+			<tbody>
+				{{#each rows}}
+					<tr>
+					{{#each this}}
+						<td>{{this}}</td>
+					{{/each}}
+					</tr>
+				{{/each}}
+			</tbody>
+		</table>
+		<button class="hide" type="submit">Perform Sort / Filter</button>
+	</form>
+</ta-belle>
+```

--- a/lib/index-cljs.js
+++ b/lib/index-cljs.js
@@ -1,4 +1,9 @@
 /* eslint-env browser */
 import { TabelleCljs } from "./components/tabelle-cljs";
+import { TabelleSearch } from "./components/tabelle-search";
 
 customElements.define("tabelle-cljs", TabelleCljs);
+
+if (!customElements.get("tabelle-search")) {
+	customElements.define("tabelle-search", TabelleSearch);
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,9 @@
 /* eslint-env browser */
 import Tabelle from "./components/tabelle/";
+import { TabelleSearch } from "./components/tabelle-search";
 
 customElements.define("ta-belle", Tabelle);
+
+if (!customElements.get("tabelle-search")) {
+	customElements.define("tabelle-search", TabelleSearch);
+}

--- a/lib/style/base.scss
+++ b/lib/style/base.scss
@@ -12,3 +12,4 @@
 @import '../components/arrow/';
 @import '../components/header/';
 @import '../components/tabelle/tabelle';
+@import '../components/tabelle-search/tabelle-search';

--- a/lib/util.js
+++ b/lib/util.js
@@ -77,26 +77,25 @@ export function submitForm (form, { headers, cors, strict } = {}) {
 }
 
 function inputsFor (form) {
-	let container = form;
-	let formSelector = "";
+	let inputsByName = [];
 	if (form.id && document.querySelector(`[form=${form.id}]`)) {
-		container = document;
-		formSelector = `[form=${form.id}]`;
+		const selectorWithFormAttr = ["input", "textarea", "select"].map(tag =>
+			`${tag}[name][form="${form.id}"]:not(:disabled)`).join(", ");
+		inputsByName = find(document, selectorWithFormAttr);
 	}
 	const selector = ["input", "textarea", "select"].map(tag =>
-		`${tag}[name]${formSelector}:not(:disabled)`).join(", ");
-	return find(container, selector);
+		`${tag}[name]:not([form]):not(:disabled)`).join(", ");
+	return inputsByName.concat(find(form, selector));
 }
 
 function radioButtonFor (form, name) {
-	let container = form;
-	let formSelector = "";
+	let radio = null;
 	if (form.id && document.querySelector(`[form=${form.id}]`)) {
-		container = document;
-		formSelector = `[form=${form.id}]`;
+		const selector = `input[type=radio][name=${name}][form="${form.id}"]:checked`;
+		radio = document.querySelector(selector);
 	}
-	let radioSelector = `input[type=radio][name=${name}]${formSelector}:checked`;
-	return container.querySelector(radioSelector);
+	let radioSelector = `input[type=radio][name=${name}]:not([form]):checked`;
+	return radio || form.querySelector(radioSelector);
 }
 
 // stringify form data as `application/x-www-form-urlencoded`


### PR DESCRIPTION
This adds a tabelle-search component which can be used to provide an
input field for users so that they can search over all of the columns
within the Tabelle. The component works with either the SSR `<ta-belle>`
component or the CSR `<tabelle-cljs>` component. See documentation for
more information.